### PR TITLE
feat: add option to disable updates checking

### DIFF
--- a/input_tool/common/parser/options.py
+++ b/input_tool/common/parser/options.py
@@ -41,6 +41,15 @@ argument_options: dict[str, tuple[tuple[str, ...], ParserOptions, Optional[str]]
         },
         "actions",
     ),
+    "update_check": (
+        ("--no-update-check",),
+        {
+            "dest": "update_check",
+            "action": "store_false",
+            "help": "[?] do not check for updates (useful when running in scripts)",
+        },
+        "actions",
+    ),
     # naming
     "indir": (
         ("--input",),

--- a/input_tool/common/parser/specifications.py
+++ b/input_tool/common/parser/specifications.py
@@ -47,6 +47,7 @@ short_description_generator = "Generate inputs based on input description file."
 options_generator = [
     "help",
     "full_help",
+    "update_check",
     "indir",
     "progdir",
     "inext",
@@ -67,6 +68,7 @@ options_generator = [
 @dataclass
 class ArgsGenerator:
     full_help: bool
+    update_check: bool
     indir: str
     progdir: str
     inext: str

--- a/input_tool/input_generator.py
+++ b/input_tool/input_generator.py
@@ -168,7 +168,8 @@ def run(args: ArgsGenerator) -> None:
     generate_all(recipe, programs, gencmd, args)
 
     check_data_folder_size(args.indir)
-    check_for_updates()
+    if args.update_check:
+        check_for_updates()
     info(str(default_logger.statistics))
 
 


### PR DESCRIPTION
Add `--no-update-check` option for `input-generator`. Useful when running it in bulk in CI, as it would just spam GitHub API and output warning when rate limit is encountered