### PR TITLE
fix: read lines without line endings

### DIFF
--- a/input_tool/input_generator.py
+++ b/input_tool/input_generator.py
@@ -61,9 +61,9 @@ def get_recipe(file: Optional[str], idf_version: int) -> Recipe:
         if os.path.isdir(file):
             file = find_idf(file)
         with open(file, "r") as f:
-            text = f.readlines()
+            text = f.read().splitlines()
     else:
-        text = sys.stdin.readlines()
+        text = sys.stdin.read().splitlines()
     return Recipe(text, idf_version)
 
 


### PR DESCRIPTION
Use `.read().splitlines()` instead of `.readlines()`, as `splitlines` returns lines without line endings. This prevented multi line inputs with backslashes as in [docs](https://github.com/fezjo/input-tool/blob/master/GENERATOR.md#viacriadkov%C3%A9-vstupy) from working correctly as `Recipe` uses `endswith` for that check:
https://github.com/fezjo/input-tool/blob/2a8b52f90fcd1376be691ec13f4db7e5d63a2ddd/input_tool/common/recipes.py#L321